### PR TITLE
add differentiation between xpack and monitoring

### DIFF
--- a/lib/facter/packetbeat_version.rb
+++ b/lib/facter/packetbeat_version.rb
@@ -1,0 +1,8 @@
+Facter.add(:packetbeat_version) do
+  setcode do
+    if Facter::Core::Execution.which('packetbeat')
+      packetbeat_version = Facter::Core::Execution.execute('packetbeat version 2>&1')
+      %r{packetbeat version:?\s+v?([\w\.]+)}.match(packetbeat_version)[1]
+    end
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,7 +94,7 @@ class packetbeat (
   Optional[Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl]] $gpg_key_url                   = undef,
   String $gpg_key_id                                                                  = '',
   Enum['enabled', 'running', 'disabled', 'unmanaged'] $service_ensure                 = 'enabled',
-  String $package_ensure                                                              = 'latest',
+  String $package_ensure                                                              = 'present',
   String $config_file_mode                                                            = '0644',
   Boolean $disable_configtest                                                         = false,
   Optional[Array[String]] $tags                                                       = undef,

--- a/spec/classes/packetbeat_spec.rb
+++ b/spec/classes/packetbeat_spec.rb
@@ -15,7 +15,7 @@ describe 'packetbeat', 'type' => 'class' do
 
         it do
           is_expected.to contain_package('packetbeat').with(
-            'ensure' => 'latest',
+            'ensure' => 'present',
           )
         end
       end

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -6,3 +6,4 @@ ipaddress: "172.16.254.254"
 ipaddress6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
 is_pe: false
 macaddress: "AA:AA:AA:AA:AA:AA"
+packetbeat_version: "7.9.1"


### PR DESCRIPTION
since xpack is partially deprecated and will be removed soon, add xpack
support only on versions 6.2.0 until < 7.2.0, after that use monitoring
instead