### PR TITLE
Replace legacy facts with modern ones

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,7 +48,7 @@
 # @param max_procs limit the amount of CPU resources packetbeat uses to this many CPU cores
 #
 class packetbeat (
-  String $beat_name                                                   = $::hostname,
+  String $beat_name                                                   = $facts['networking']['hostname'],
   Boolean $fields_under_root                                          = false,
   Hash $queue                                                         = {
     'mem' => {

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -21,7 +21,7 @@ class packetbeat::repo inherits packetbeat {
   }
 
   if ($packetbeat::manage_repo == true) and ($packetbeat::ensure == 'present') {
-    case $facts['osfamily'] {
+    case $facts['os']['family'] {
       'Debian': {
         include ::apt
         if !defined(Apt::Source['beats']) {


### PR DESCRIPTION
Puppet 8 agents do not send legacy facts per default