### PR TITLE
Service restart on update

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -121,8 +121,14 @@ class packetbeat (
   case $ensure {
     'present': {
       Class['packetbeat::install']
-      ->Class['packetbeat::config']
-      ~>Class['packetbeat::service']
+      -> Class['packetbeat::config']
+      -> Class['packetbeat::service']
+
+      Class['packetbeat::install']
+      ~> Class['packetbeat::service']
+
+      Class['packetbeat::config']
+      ~> Class['packetbeat::service']
     }
     default: {
       Class['packetbeat::service']


### PR DESCRIPTION
The service does not restart when packetbeat is updated. Thus, the service has to be restarted manually before the new version is used. However, this should be done automatically after updating.